### PR TITLE
bug/image/upload-buffer

### DIFF
--- a/aws/s3storage.js
+++ b/aws/s3storage.js
@@ -1,6 +1,5 @@
 const aws = require('aws-sdk')
 const dotenv = require('dotenv')
-const fs = require('fs');
 
 dotenv.config()
 
@@ -22,9 +21,8 @@ async function getImgURL() {
   }
 }
 
-async function uploadImg(imgSrc, imgName) {
+async function uploadImg(fileBuffer, imgName) {
   try {
-    const fileContent = fs.readFileSync(imgSrc);
     const s3 = new aws.S3({
       accessKeyId: process.env.AWS_ACCESS_KEY,
       secretAccessKey: process.env.AWS_SECRET_KEY
@@ -32,7 +30,7 @@ async function uploadImg(imgSrc, imgName) {
     await s3.upload({
       Bucket: process.env.BUCKET_NAME,
       Key: imgName,
-      Body: fileContent,
+      Body: fileBuffer,
       ACL: "public-read-write"
     }).promise()
   }

--- a/image/router.js
+++ b/image/router.js
@@ -9,7 +9,7 @@ const router = new Router()
 
 router.post('/image', upload.single('image'), async (req, res, next) => {
   if (req.file) {
-    await uploadImg(req.file.path, 'newimage.jpg')
+    await uploadImg(req.file.buffer, 'newimage.jpg')
     const imgURL = await getImgURL()
     const guess = await predictImage(imgURL)
     res.send(guess)


### PR DESCRIPTION
The upload function to AWS no longer uses the fs library as now it takes the buffer property of the image that is sent through the post request and immediately uploads it.