### PR TITLE
Changed the run command to npm start in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN npm install -g nodemon
 COPY . .
 #Expose port and start application
 EXPOSE 4000
-CMD [ "npm", "run", "dev" ]
+CMD [ "npm", "start" ]


### PR DESCRIPTION
A quick fix to changing the run command in Dockerfile to "npm start", to be able to deploy on Heroku